### PR TITLE
build: upgrade to AGP 8.7.3 and Gradle 8.11 for 16KB page size support

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,6 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx3072M -XX:MaxMetaspaceSize=1024m
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 #android.enableR8=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.4" apply false
+    id "com.android.application" version "8.7.3" apply false
     id "org.jetbrains.kotlin.android" version "2.0.21" apply false
 }
 


### PR DESCRIPTION
## Problem

Google Play now requires apps to support 16KB memory page sizes when targeting Android 15 (API 35). Our current build configuration doesn't meet this requirement, causing this error when uploading AAB files:

> Your app does not support 16 KB memory page sizes

## Solution

This PR upgrades the Android build toolchain to support 16KB page sizes:

### Build Tool Upgrades
- **Android Gradle Plugin**: 8.1.4 → 8.7.3
- **Gradle**: 8.5 → 8.11

AGP 8.5.1+ automatically aligns native libraries to 16KB page boundaries during the packaging process, which is exactly what Google Play requires.

### Build Configuration Updates
- **JVM heap size**: 1.5GB → 3GB (`-Xmx3072M`)
- **MaxMetaspaceSize**: Added 1GB limit (`-XX:MaxMetaspaceSize=1024m`)
- **Jetifier**: Disabled (`android.enableJetifier=false`)

### Why Disable Jetifier?

Jetifier was causing "Java heap space" errors during the build transform phase with AGP 8.7+. It's safe to disable because:
- All project dependencies have been migrated to AndroidX
- Jetifier is outdated and adds unnecessary overhead
- The error in CI was: \`Failed to transform ... Execution failed for JetifyTransform ... Java heap space\`

## Testing

The CI build will verify:
- Debug APK builds successfully
- Release AAB builds successfully
- All tests pass

Once merged, the next AAB uploaded to Google Play should pass the 16KB page size requirement.

## References

- [Support 16 KB page sizes | Android Developers](https://developer.android.com/guide/practices/page-sizes)
- [Android Gradle Plugin 8.7.0 Release Notes](https://developer.android.com/build/releases/agp-8-7-0-release-notes)
- [Android's 16 KB Page Size Requirement](https://proandroiddev.com/androids-16-kb-page-size-requirement-what-it-is-and-how-to-prepare-2d8b72bbcc3e)

## Changes

- `android/settings.gradle`: AGP version bump
- `android/gradle/wrapper/gradle-wrapper.properties`: Gradle version bump
- `android/gradle.properties`: Heap size increase + disable Jetifier

## Summary by Sourcery

Upgrade Android build tooling to meet 16KB page size requirements and adjust related Gradle configuration.

Build:
- Upgrade Gradle wrapper from 8.5 to 8.11.
- Upgrade Android Gradle Plugin from 8.1.4 to 8.7.3.
- Increase Gradle JVM heap size and cap metaspace usage in gradle.properties.
- Disable Jetifier in the Android Gradle configuration.